### PR TITLE
Codecov integration

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.9.7"
           architecture: x64
 
-      - name: intall virtualenv
+      - name: install virtualenv
         run: pip install virtualenv
 
       - name: Install python dependencies
@@ -52,3 +52,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
           FOLDER: dist/
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2


### PR DESCRIPTION
## Changelog
- [x] Correction for the virtualenv install step.
- [x] Codecov has been integrated and set up in the workflow.

## Anything to note?
The `CODECOV_TOKEN` has not been added into the workflow step, since it is not required for public repos.
However, is stored in a local `.env`, and is available upon request.